### PR TITLE
Add dive computer simulator prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# dive_computer
+# Dive Computer Simulator
+
+A browser-based simulator that mimics a single-tank recreational dive computer. The left side of the interface visualizes real-time telemetry (depth, dive time, NDL, TTS, PO₂, gas remaining, etc.), while the right side provides controls to manipulate the dive environment and diver parameters.
+
+## Getting started
+
+```bash
+# from the project root
+python -m http.server 8000
+```
+
+Then open <http://localhost:8000> in your browser to interact with the simulator.
+
+## Features
+
+- **Dynamic dive profile** – set a target depth (default 5 m) and ascent/descent rate; the simulated diver transitions toward the target while accumulating statistics once below 5 m.
+- **Bühlmann-based tissue loading** – 16 nitrogen compartments update every simulation tick and derive a simplified no-decompression limit (NDL) using the selected gradient-factor high value.
+- **Gas consumption model** – configure cylinder size, fill pressure, and O₂ fraction before the dive. Once the diver crosses 5 m, these controls lock, and remaining pressure updates automatically from surface SAC and workload.
+- **Safety insights** – live PO₂, tank pressure gauge, ascent time (with optional safety-stop credit), and status banner for approaching limits.
+- **Time control** – play/pause/reset buttons with 1× or 5× time scaling for quick scenarios.
+
+## Key controls
+
+| Group | Controls | Notes |
+| --- | --- | --- |
+| Environment | Target depth slider, ascent/descent rate, water temperature | Depth drives most calculations; temperature is informational for future hooks. |
+| Gas & Cylinder | Cylinder size, fill pressure, O₂ fraction | Locked once the dive becomes active (depth ≥ 5 m). |
+| Diver | Surface SAC, workload multiplier, gradient factors | Workload scales gas consumption; gradient factor high adjusts the conservative NDL estimate. |
+| Simulation | Play/Pause/Reset, time scale | Reset returns to surface, refills the tank, and reinitializes tissue compartments. |
+
+## Notes
+
+- The Bühlmann implementation is intentionally simplified for educational visualization and should not be used for real dive planning.
+- Future enhancements could include configurable depth scripting, logging/replay, and export functionality.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dive Computer Simulator</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="app">
+    <header class="app__header">
+      <h1>Dive Computer Simulator</h1>
+      <p class="app__subtitle">Real-time dive computer metrics driven by adjustable environment and diver parameters.</p>
+    </header>
+    <main class="app__main">
+      <section class="computer" aria-label="Dive computer display">
+        <div class="computer__screen">
+          <div class="computer__row">
+            <div class="computer__tile">
+              <h2>Depth</h2>
+              <p><span id="current-depth">0.0</span> m</p>
+            </div>
+            <div class="computer__tile">
+              <h2>Dive Time</h2>
+              <p><span id="dive-time">00:00</span></p>
+            </div>
+            <div class="computer__tile">
+              <h2>NDL</h2>
+              <p><span id="ndl">--</span> min</p>
+            </div>
+          </div>
+          <div class="computer__row">
+            <div class="computer__tile">
+              <h2>TTS</h2>
+              <p><span id="tts">--</span> min</p>
+            </div>
+            <div class="computer__tile">
+              <h2>Avg / Max</h2>
+              <p><span id="avg-depth">0.0</span> m / <span id="max-depth">0.0</span> m</p>
+            </div>
+            <div class="computer__tile">
+              <h2>PO<sub>2</sub></h2>
+              <p><span id="po2">0.21</span> bar</p>
+            </div>
+          </div>
+          <div class="computer__row">
+            <div class="computer__tile computer__tile--wide">
+              <h2>Tank</h2>
+              <div class="tank">
+                <div class="tank__bar" id="tank-bar"><div class="tank__bar-fill" id="tank-bar-fill"></div></div>
+                <div class="tank__metrics">
+                  <p>Pressure: <span id="tank-pressure">0</span> bar</p>
+                  <p>Gas Remaining: <span id="gas-remaining">0</span> L</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="computer__row">
+            <div class="computer__tile computer__tile--wide">
+              <h2>Status</h2>
+              <p id="status-text">Standby</p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="controls" aria-label="Simulation controls">
+        <form id="controls-form">
+          <fieldset>
+            <legend>Environment</legend>
+            <label for="target-depth">Target Depth (m)</label>
+            <input type="range" id="target-depth" min="0" max="60" step="0.5" value="5" />
+            <div class="controls__value" id="target-depth-value">5.0 m</div>
+
+            <label for="rate">Ascent/Descent Rate (m/min)</label>
+            <input type="number" id="rate" min="1" max="30" value="10" />
+
+            <label for="water-temp">Water Temperature (°C)</label>
+            <input type="number" id="water-temp" min="-2" max="35" value="26" />
+          </fieldset>
+
+          <fieldset id="gas-settings">
+            <legend>Gas &amp; Cylinder (locked once dive starts)</legend>
+            <label for="cylinder-size">Cylinder Size (L)</label>
+            <select id="cylinder-size">
+              <option value="10">10 L Steel</option>
+              <option value="11.1">11.1 L AL80</option>
+              <option value="12" selected>12 L Steel</option>
+              <option value="15">15 L Steel</option>
+            </select>
+
+            <label for="fill-pressure">Fill Pressure (bar)</label>
+            <input type="number" id="fill-pressure" min="50" max="300" value="200" />
+
+            <label for="o2">O<sub>2</sub> Fraction (%)</label>
+            <input type="number" id="o2" min="21" max="40" value="21" />
+          </fieldset>
+
+          <fieldset>
+            <legend>Diver</legend>
+            <label for="sac">Surface SAC (L/min)</label>
+            <input type="number" id="sac" min="5" max="35" value="18" />
+
+            <label for="workload">Workload Multiplier</label>
+            <input type="range" id="workload" min="0.5" max="3" step="0.1" value="1.0" />
+            <div class="controls__value" id="workload-value">1.0×</div>
+
+            <label for="gf-low">Gradient Factor Low</label>
+            <input type="number" id="gf-low" min="10" max="99" value="30" />
+
+            <label for="gf-high">Gradient Factor High</label>
+            <input type="number" id="gf-high" min="10" max="99" value="85" />
+          </fieldset>
+
+          <fieldset>
+            <legend>Simulation</legend>
+            <div class="controls__buttons">
+              <button type="button" id="play">Play</button>
+              <button type="button" id="pause">Pause</button>
+              <button type="button" id="reset">Reset</button>
+            </div>
+            <label for="time-scale">Time Scale</label>
+            <select id="time-scale">
+              <option value="1" selected>1×</option>
+              <option value="5">5×</option>
+            </select>
+          </fieldset>
+        </form>
+      </section>
+    </main>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,409 @@
+const SURFACE_PRESSURE = 1;
+const WATER_DENSITY_DIVISOR = 10; // 10 m of salt water ~ 1 bar
+const BASE_TICK_MS = 1000;
+const DIVE_START_THRESHOLD = 5; // m
+const SAFETY_STOP_DEPTH = 5;
+const SAFETY_STOP_DURATION = 180; // seconds
+const WATER_VAPOR_PRESSURE = 0; // simplified model
+
+const compartments = [
+  { halfTime: 5, a: 1.1696, b: 0.5578, pressure: 0 },
+  { halfTime: 8, a: 1.0, b: 0.6514, pressure: 0 },
+  { halfTime: 12.5, a: 0.8618, b: 0.7222, pressure: 0 },
+  { halfTime: 18.5, a: 0.7562, b: 0.7825, pressure: 0 },
+  { halfTime: 27, a: 0.6667, b: 0.8125, pressure: 0 },
+  { halfTime: 38.3, a: 0.6164, b: 0.8434, pressure: 0 },
+  { halfTime: 54.3, a: 0.5545, b: 0.8693, pressure: 0 },
+  { halfTime: 77, a: 0.4980, b: 0.8910, pressure: 0 },
+  { halfTime: 109, a: 0.4410, b: 0.9092, pressure: 0 },
+  { halfTime: 146, a: 0.4187, b: 0.9222, pressure: 0 },
+  { halfTime: 187, a: 0.3798, b: 0.9319, pressure: 0 },
+  { halfTime: 239, a: 0.3497, b: 0.9403, pressure: 0 },
+  { halfTime: 305, a: 0.3223, b: 0.9477, pressure: 0 },
+  { halfTime: 390, a: 0.2971, b: 0.9544, pressure: 0 },
+  { halfTime: 498, a: 0.2737, b: 0.9602, pressure: 0 },
+  { halfTime: 635, a: 0.2523, b: 0.9653, pressure: 0 }
+];
+
+const ui = {
+  currentDepth: document.getElementById('current-depth'),
+  diveTime: document.getElementById('dive-time'),
+  ndl: document.getElementById('ndl'),
+  tts: document.getElementById('tts'),
+  avgDepth: document.getElementById('avg-depth'),
+  maxDepth: document.getElementById('max-depth'),
+  po2: document.getElementById('po2'),
+  tankPressure: document.getElementById('tank-pressure'),
+  gasRemaining: document.getElementById('gas-remaining'),
+  tankBarFill: document.getElementById('tank-bar-fill'),
+  statusText: document.getElementById('status-text'),
+  targetDepthValue: document.getElementById('target-depth-value'),
+  workloadValue: document.getElementById('workload-value')
+};
+
+const controls = {
+  targetDepth: document.getElementById('target-depth'),
+  rate: document.getElementById('rate'),
+  waterTemp: document.getElementById('water-temp'),
+  cylinderSize: document.getElementById('cylinder-size'),
+  fillPressure: document.getElementById('fill-pressure'),
+  o2: document.getElementById('o2'),
+  sac: document.getElementById('sac'),
+  workload: document.getElementById('workload'),
+  gfLow: document.getElementById('gf-low'),
+  gfHigh: document.getElementById('gf-high'),
+  play: document.getElementById('play'),
+  pause: document.getElementById('pause'),
+  reset: document.getElementById('reset'),
+  timeScale: document.getElementById('time-scale'),
+  gasSettings: document.getElementById('gas-settings')
+};
+
+const state = {
+  depth: 0,
+  targetDepth: Number(controls.targetDepth.value),
+  elapsedTime: 0,
+  diveTime: 0,
+  avgDepth: 0,
+  maxDepth: 0,
+  isPlaying: false,
+  diveActive: false,
+  safetyStopTimer: 0,
+  initialGasVolume: 0,
+  remainingGasVolume: 0,
+  tankPressure: 0,
+  lockGasSettings: false
+};
+
+function initializeCompartments() {
+  const fn2 = getFN2();
+  const initialPressure = fn2 * SURFACE_PRESSURE;
+  compartments.forEach((comp) => {
+    comp.pressure = initialPressure;
+  });
+}
+
+function getFO2() {
+  return Math.max(0.21, Math.min(0.4, Number(controls.o2.value) / 100));
+}
+
+function getFN2() {
+  return 1 - getFO2();
+}
+
+function calculateTankVolumes() {
+  const size = Number(controls.cylinderSize.value);
+  const fillPressure = Number(controls.fillPressure.value);
+  state.initialGasVolume = size * fillPressure;
+  if (!state.diveActive) {
+    state.remainingGasVolume = state.initialGasVolume;
+    state.tankPressure = fillPressure;
+  }
+}
+
+function formatTime(seconds) {
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+}
+
+function updateUI() {
+  ui.currentDepth.textContent = state.depth.toFixed(1);
+  ui.diveTime.textContent = formatTime(state.diveTime);
+  ui.avgDepth.textContent = state.avgDepth.toFixed(1);
+  ui.maxDepth.textContent = state.maxDepth.toFixed(1);
+
+  const ndl = calculateNDL();
+  ui.ndl.textContent = Number.isFinite(ndl) ? ndl.toFixed(0) : '∞';
+  ui.tts.textContent = calculateTTS().toFixed(1);
+
+  const po2 = getFO2() * getAmbientPressure(state.depth);
+  ui.po2.textContent = po2.toFixed(2);
+
+  ui.tankPressure.textContent = state.tankPressure.toFixed(0);
+  ui.gasRemaining.textContent = Math.max(state.remainingGasVolume, 0).toFixed(0);
+
+  const tankFill = state.initialGasVolume > 0 ? Math.max(state.remainingGasVolume / state.initialGasVolume, 0) : 0;
+  ui.tankBarFill.style.height = `${(tankFill * 100).toFixed(1)}%`;
+
+  const status = deriveStatus(po2, ndl, tankFill);
+  ui.statusText.textContent = status.text;
+  ui.statusText.className = `status-${status.level}`;
+}
+
+function deriveStatus(po2, ndl, tankFill) {
+  if (!state.diveActive) {
+    return { text: 'Standby', level: 'normal' };
+  }
+  if (po2 >= 1.6) {
+    return { text: 'PO₂ Critical', level: 'danger' };
+  }
+  if (po2 >= 1.4) {
+    return { text: 'PO₂ High', level: 'warning' };
+  }
+  if (tankFill <= 0.1) {
+    return { text: 'Reserve Gas', level: 'danger' };
+  }
+  if (tankFill <= 0.25) {
+    return { text: 'Low Gas', level: 'warning' };
+  }
+  if (ndl <= 3) {
+    return { text: 'NDL Critical', level: 'danger' };
+  }
+  if (ndl <= 10) {
+    return { text: 'Approaching NDL', level: 'warning' };
+  }
+  return { text: 'Diving', level: 'normal' };
+}
+
+function getAmbientPressure(depth) {
+  return SURFACE_PRESSURE + depth / WATER_DENSITY_DIVISOR;
+}
+
+function updateCompartments(dtSeconds) {
+  const fn2 = getFN2();
+  const ambientPressure = getAmbientPressure(state.depth);
+  const inspiredPressure = Math.max(0, (ambientPressure - WATER_VAPOR_PRESSURE) * fn2);
+  compartments.forEach((comp) => {
+    const rateConstant = Math.log(2) / comp.halfTime;
+    const delta = inspiredPressure - comp.pressure;
+    comp.pressure += delta * (1 - Math.exp(-rateConstant * (dtSeconds / 60)));
+  });
+}
+
+function getGradientFactor() {
+  const gfLow = Math.max(0.1, Math.min(0.99, Number(controls.gfLow.value) / 100));
+  const gfHigh = Math.max(gfLow, Math.min(0.99, Number(controls.gfHigh.value) / 100));
+  const blendDepth = Math.min(state.depth, 30);
+  const t = Math.max(0, Math.min(1, 1 - blendDepth / 30));
+  const gf = gfLow + (gfHigh - gfLow) * t;
+  return Math.max(0.1, Math.min(0.99, gf));
+}
+
+function calculateNDL() {
+  const gf = getGradientFactor();
+  const fn2 = getFN2();
+  const ambientPressure = getAmbientPressure(state.depth);
+  const inspiredPressure = Math.max(0, (ambientPressure - WATER_VAPOR_PRESSURE) * fn2);
+
+  if (inspiredPressure <= 0) {
+    return Infinity;
+  }
+
+  let ndlMinutes = Infinity;
+
+  compartments.forEach((comp) => {
+    const a = comp.a;
+    const b = comp.b;
+    const m0 = a + (SURFACE_PRESSURE / b);
+    const allowed = SURFACE_PRESSURE + (m0 - SURFACE_PRESSURE) * gf;
+
+    if (allowed <= comp.pressure) {
+      ndlMinutes = Math.min(ndlMinutes, 0);
+      return;
+    }
+
+    if (inspiredPressure <= comp.pressure) {
+      return;
+    }
+
+    const numerator = allowed - comp.pressure;
+    const denominator = inspiredPressure - comp.pressure;
+    if (numerator <= 0 || denominator <= 0) {
+      ndlMinutes = Math.min(ndlMinutes, 0);
+      return;
+    }
+
+    const rateConstant = Math.log(2) / comp.halfTime;
+    const time = -Math.log(1 - numerator / denominator) / rateConstant;
+    ndlMinutes = Math.min(ndlMinutes, time);
+  });
+
+  return ndlMinutes;
+}
+
+function calculateTTS() {
+  if (!state.diveActive) return 0;
+  const rate = Math.max(1, Number(controls.rate.value));
+  const ascentTime = state.depth / rate; // minutes
+  let stop = 0;
+  if (state.depth >= SAFETY_STOP_DEPTH + 1 && state.diveTime > 600) {
+    stop = SAFETY_STOP_DURATION / 60;
+  }
+  return ascentTime + stop;
+}
+
+function updateGas(dtSeconds) {
+  if (!state.diveActive) {
+    return;
+  }
+  const surfaceSac = Number(controls.sac.value);
+  const workload = Number(controls.workload.value);
+  const ambientPressure = getAmbientPressure(state.depth);
+  const sac = surfaceSac * ambientPressure * workload; // L/min
+  const consumed = (sac / 60) * dtSeconds;
+  state.remainingGasVolume = Math.max(0, state.remainingGasVolume - consumed);
+  const size = Number(controls.cylinderSize.value);
+  state.tankPressure = size > 0 ? (state.remainingGasVolume / size) : 0;
+}
+
+function updateAverages(dtSeconds) {
+  state.elapsedTime += dtSeconds;
+  if (state.depth >= DIVE_START_THRESHOLD) {
+    state.diveActive = true;
+    state.diveTime += dtSeconds;
+    state.avgDepth = ((state.avgDepth * (state.diveTime - dtSeconds)) + state.depth * dtSeconds) / state.diveTime;
+    state.maxDepth = Math.max(state.maxDepth, state.depth);
+  }
+}
+
+function updateDepth(dtSeconds) {
+  const target = state.targetDepth;
+  const ratePerSecond = Math.max(0.1, Number(controls.rate.value) / 60);
+  const difference = target - state.depth;
+
+  if (Math.abs(difference) < ratePerSecond * dtSeconds) {
+    state.depth = target;
+  } else {
+    state.depth += Math.sign(difference) * ratePerSecond * dtSeconds;
+  }
+
+  if (state.depth < 0.01) {
+    state.depth = 0;
+  }
+}
+
+let tickHandle = null;
+function tick() {
+  if (!state.isPlaying) return;
+  const timeScale = Number(controls.timeScale.value);
+  const dtSeconds = timeScale;
+
+  updateDepth(dtSeconds);
+  updateAverages(dtSeconds);
+  updateCompartments(dtSeconds);
+  updateGas(dtSeconds);
+  updateUI();
+
+  handleGasLock();
+}
+
+function handleGasLock() {
+  if (state.diveActive && !state.lockGasSettings) {
+    state.lockGasSettings = true;
+    controls.cylinderSize.disabled = true;
+    controls.fillPressure.disabled = true;
+    controls.o2.disabled = true;
+  }
+}
+
+function resetGasLock() {
+  state.lockGasSettings = false;
+  controls.cylinderSize.disabled = false;
+  controls.fillPressure.disabled = false;
+  controls.o2.disabled = false;
+}
+
+function play() {
+  if (state.isPlaying) return;
+  state.isPlaying = true;
+  tickHandle = setInterval(tick, BASE_TICK_MS);
+}
+
+function pause() {
+  state.isPlaying = false;
+  if (tickHandle) {
+    clearInterval(tickHandle);
+    tickHandle = null;
+  }
+}
+
+function reset() {
+  pause();
+  state.depth = 0;
+  state.targetDepth = Number(controls.targetDepth.value);
+  state.elapsedTime = 0;
+  state.diveTime = 0;
+  state.avgDepth = 0;
+  state.maxDepth = 0;
+  state.diveActive = false;
+  state.safetyStopTimer = 0;
+  resetGasLock();
+  clampGradientFactors();
+  calculateTankVolumes();
+  initializeCompartments();
+  updateUI();
+}
+
+function updateTargetDepthLabel() {
+  state.targetDepth = Number(controls.targetDepth.value);
+  ui.targetDepthValue.textContent = `${state.targetDepth.toFixed(1)} m`;
+}
+
+function updateWorkloadLabel() {
+  ui.workloadValue.textContent = `${Number(controls.workload.value).toFixed(1)}×`;
+}
+
+function clampGradientFactors() {
+  let low = Number(controls.gfLow.value);
+  let high = Number(controls.gfHigh.value);
+  low = Math.max(10, Math.min(99, Math.round(low)));
+  high = Math.max(10, Math.min(99, Math.round(high)));
+  if (low >= high) {
+    high = Math.min(99, low + 1);
+    if (high <= low) {
+      low = Math.max(10, high - 1);
+    }
+  }
+  controls.gfLow.value = low;
+  controls.gfHigh.value = high;
+}
+
+controls.targetDepth.addEventListener('input', () => {
+  updateTargetDepthLabel();
+});
+
+controls.workload.addEventListener('input', () => {
+  updateWorkloadLabel();
+});
+
+controls.rate.addEventListener('change', () => {
+  controls.rate.value = Math.max(1, Math.min(30, Number(controls.rate.value)));
+});
+
+controls.gfLow.addEventListener('change', () => {
+  clampGradientFactors();
+});
+
+controls.gfHigh.addEventListener('change', () => {
+  clampGradientFactors();
+});
+
+controls.cylinderSize.addEventListener('change', calculateTankVolumes);
+controls.fillPressure.addEventListener('change', calculateTankVolumes);
+controls.o2.addEventListener('change', () => {
+  if (state.diveActive) return;
+  calculateTankVolumes();
+  initializeCompartments();
+});
+
+controls.sac.addEventListener('change', () => {
+  controls.sac.value = Math.max(5, Math.min(35, Number(controls.sac.value)));
+});
+
+controls.play.addEventListener('click', play);
+controls.pause.addEventListener('click', pause);
+controls.reset.addEventListener('click', reset);
+
+controls.timeScale.addEventListener('change', () => {
+  if (!state.isPlaying) return;
+  pause();
+  play();
+});
+
+calculateTankVolumes();
+initializeCompartments();
+updateTargetDepthLabel();
+updateWorkloadLabel();
+clampGradientFactors();
+updateUI();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,243 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: #10141a;
+  color: #f4f7fa;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, #1d2733, #0c1116 60%);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 2rem 1rem;
+}
+
+.app {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app__header {
+  text-align: center;
+}
+
+.app__subtitle {
+  color: #9fb2c8;
+  margin-top: 0.5rem;
+}
+
+.app__main {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr);
+  gap: 1.5rem;
+}
+
+.computer {
+  background: linear-gradient(160deg, #1f2a36, #111820);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 25px 40px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.computer__screen {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.computer__row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.computer__tile {
+  background: rgba(12, 18, 24, 0.85);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.computer__tile h2 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #8aa7c6;
+  margin: 0 0 0.5rem;
+}
+
+.computer__tile p {
+  font-size: 1.6rem;
+  margin: 0;
+}
+
+.computer__tile--wide {
+  grid-column: span 3;
+}
+
+.tank {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.tank__bar {
+  width: 100px;
+  height: 140px;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #1a6fb3, #0b2842);
+  position: relative;
+  overflow: hidden;
+}
+
+.tank__bar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent 70%);
+}
+
+.tank__bar-fill {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: linear-gradient(180deg, #26c6da, #00838f);
+  transition: height 0.3s ease;
+}
+
+.tank__metrics p {
+  margin: 0;
+  font-size: 1rem;
+  color: #d0e0f0;
+}
+
+.controls {
+  background: rgba(9, 13, 17, 0.9);
+  border-radius: 20px;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+}
+
+#controls-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
+}
+
+fieldset {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(20, 28, 38, 0.65);
+}
+
+legend {
+  padding: 0 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #8aa7c6;
+}
+
+label {
+  font-size: 0.9rem;
+  color: #cbd9e6;
+}
+
+input,
+select {
+  padding: 0.5rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(10, 16, 22, 0.8);
+  color: #f4f7fa;
+  font-size: 1rem;
+}
+
+input[type="range"] {
+  accent-color: #26c6da;
+}
+
+.controls__value {
+  font-size: 0.9rem;
+  color: #9fb2c8;
+  text-align: right;
+}
+
+.controls__buttons {
+  display: flex;
+  gap: 0.75rem;
+}
+
+button {
+  flex: 1;
+  padding: 0.6rem;
+  background: linear-gradient(160deg, #1b9aaa, #136f8a);
+  border: none;
+  border-radius: 8px;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.25);
+}
+
+button:disabled {
+  background: #2f3c4a;
+  color: #7f92a8;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.status-normal {
+  color: #81c784;
+}
+
+.status-warning {
+  color: #ffb74d;
+}
+
+.status-danger {
+  color: #ef5350;
+}
+
+@media (max-width: 900px) {
+  .app__main {
+    grid-template-columns: 1fr;
+  }
+
+  .computer__row {
+    grid-template-columns: 1fr;
+  }
+
+  .computer__tile--wide {
+    grid-column: span 1;
+  }
+
+  .tank {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .tank__bar {
+    width: 80px;
+    height: 160px;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder README with launch instructions and an overview of the simulator controls and features
- add an HTML/CSS/JS single-page app that displays dive-computer telemetry beside adjustable environment, gas, and diver controls
- implement simplified Bühlmann tissue loading, SAC-based gas consumption, and status/warning indicators tied to the simulation loop

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6434b1c308322bb81d4ed410a5402