### PR TITLE
Add deco stop handling for negative NDL values

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,11 @@ body {
   margin: 0;
 }
 
+.ndl--deco {
+  color: #ff6b6b;
+  font-weight: 700;
+}
+
 .computer__tile--wide {
   grid-column: span 3;
 }


### PR DESCRIPTION
## Summary
- show a deco stop depth and remaining time when NDL reaches zero or below, and mark the readout in red
- add gradient factor utilities and deco stop estimation to keep the status banner aligned with the NDL display
- style the deco indication with a dedicated class

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d64e8374b88322b2102a337a27a181