### PR TITLE
Add MOD alert and clarify NDL warnings

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -240,6 +240,21 @@ button:disabled {
   font-weight: 700;
 }
 
+.status-low-ndl {
+  color: #ffca28;
+  font-weight: 700;
+}
+
+.status-deco-needed {
+  color: #ff6b6b;
+  font-weight: 700;
+}
+
+.status-mod-alert {
+  color: #ff5252;
+  font-weight: 800;
+}
+
 .speed-indicator {
   --speed-color: #4db6ac;
   display: flex;


### PR DESCRIPTION
## Summary
- calculate MOD from the configured FO₂ and warn when current depth exceeds safe limits
- clarify status messaging for low NDL and deco requirements while refining PO₂ alerts
- style the new status states with dedicated colors for easier identification

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6539da6008322a47de0ab5de082aa