### PR TITLE
Add water temperature display to dive computer screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
               <p><span id="dive-time">00:00</span></p>
             </div>
             <div class="computer__tile">
+              <h2>水溫</h2>
+              <p><span id="water-temp-display">26</span> °C</p>
+            </div>
+            <div class="computer__tile">
               <h2>無減壓極限 / 安全停留</h2>
               <p><span id="ndl">--</span><span id="ndl-unit"> 分鐘</span></p>
             </div>

--- a/script.js
+++ b/script.js
@@ -45,7 +45,8 @@ const ui = {
   targetDepthValue: document.getElementById('target-depth-value'),
   workloadValue: document.getElementById('workload-value'),
   verticalSpeed: document.getElementById('vertical-speed'),
-  speedIndicator: document.getElementById('speed-indicator')
+  speedIndicator: document.getElementById('speed-indicator'),
+  waterTemp: document.getElementById('water-temp-display')
 };
 
 const controls = {
@@ -121,6 +122,9 @@ function updateUI() {
   ui.diveTime.textContent = formatTime(state.diveTime);
   ui.avgDepth.textContent = state.avgDepth.toFixed(1);
   ui.maxDepth.textContent = state.maxDepth.toFixed(1);
+  if (ui.waterTemp) {
+    ui.waterTemp.textContent = controls.waterTemp.value;
+  }
   updateSpeedIndicator();
 
   const ndl = calculateNDL();

--- a/styles.css
+++ b/styles.css
@@ -53,7 +53,7 @@ body {
 
 .computer__row {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 1rem;
 }
 
@@ -89,7 +89,7 @@ body {
 }
 
 .computer__tile--wide {
-  grid-column: span 3;
+  grid-column: 1 / -1;
 }
 
 .tank {


### PR DESCRIPTION
## Summary
- add a water temperature tile to the dive computer display with a dedicated span
- update the UI logic to read the current water temperature control value and show it on the screen
- tweak the screen grid layout so the new tile fits cleanly with the existing tiles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6582d886c83229aa978ed9d481814