### PR TITLE
Preserve entire dive depth history

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,15 @@
             </div>
           </div>
           <div class="computer__row">
+            <div class="computer__tile computer__tile--wide computer__tile--chart">
+              <div class="computer__chart-header">
+                <h2>深度歷史</h2>
+                <p class="computer__chart-description">最近 5 分鐘深度變化</p>
+              </div>
+              <canvas id="depth-chart" aria-label="深度歷史圖"></canvas>
+            </div>
+          </div>
+          <div class="computer__row">
             <div class="computer__tile computer__tile--wide">
               <h2>狀態</h2>
               <p id="status-text">待命</p>

--- a/script.js
+++ b/script.js
@@ -29,6 +29,8 @@ const compartments = [
   { halfTime: 635, a: 0.2523, b: 0.9653, pressure: 0 }
 ];
 
+const depthChartCanvas = document.getElementById('depth-chart');
+
 const ui = {
   currentDepth: document.getElementById('current-depth'),
   diveTime: document.getElementById('dive-time'),
@@ -46,7 +48,9 @@ const ui = {
   workloadValue: document.getElementById('workload-value'),
   verticalSpeed: document.getElementById('vertical-speed'),
   speedIndicator: document.getElementById('speed-indicator'),
-  waterTemp: document.getElementById('water-temp-display')
+  waterTemp: document.getElementById('water-temp-display'),
+  depthChartCanvas,
+  depthChartCtx: depthChartCanvas ? depthChartCanvas.getContext('2d') : null
 };
 
 const controls = {
@@ -82,7 +86,10 @@ const state = {
   tankPressure: 0,
   lockGasSettings: false,
   lastDepth: 0,
-  verticalSpeed: 0
+  verticalSpeed: 0,
+  depthHistory: [],
+  maxHistorySeconds: null,
+  maxHistoryPoints: null
 };
 
 function initializeCompartments() {
@@ -167,6 +174,8 @@ function updateUI() {
   const status = deriveStatus(po2, ndl, tankFill);
   ui.statusText.textContent = status.text;
   ui.statusText.className = `status-${status.level}`;
+
+  renderDepthChart();
 }
 
 function deriveStatus(po2, ndl, tankFill) {
@@ -217,6 +226,177 @@ function deriveStatus(po2, ndl, tankFill) {
     return { text: 'NDL NEAR LIMIT / 接近無減壓極限', level: 'warning' };
   }
   return { text: '下潛中', level: 'normal' };
+}
+
+function renderDepthChart() {
+  const canvas = ui.depthChartCanvas;
+  const ctx = ui.depthChartCtx;
+  if (!canvas || !ctx) {
+    return;
+  }
+
+  const width = canvas.clientWidth;
+  const height = canvas.clientHeight;
+  if (width === 0 || height === 0) {
+    return;
+  }
+
+  const dpr = window.devicePixelRatio || 1;
+  const displayWidth = Math.round(width * dpr);
+  const displayHeight = Math.round(height * dpr);
+  if (canvas.width !== displayWidth || canvas.height !== displayHeight) {
+    canvas.width = displayWidth;
+    canvas.height = displayHeight;
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+  const styles = getComputedStyle(document.documentElement);
+  const readVar = (name, fallback) => {
+    const value = styles.getPropertyValue(name);
+    return value ? value.trim() || fallback : fallback;
+  };
+
+  const gradientStart = readVar('--chart-gradient-start', '#1a2b3a');
+  const gradientEnd = readVar('--chart-gradient-end', '#0c141d');
+  const gridColor = readVar('--chart-grid', 'rgba(255, 255, 255, 0.06)');
+  const lineColor = readVar('--chart-line', '#26c6da');
+  const fillColor = readVar('--chart-fill', 'rgba(38, 198, 218, 0.22)');
+  const markerColor = readVar('--chart-marker', '#ffcc66');
+  const placeholderColor = readVar('--chart-placeholder', '#6f8399');
+
+  ctx.clearRect(0, 0, width, height);
+
+  const gradient = ctx.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, gradientStart);
+  gradient.addColorStop(1, gradientEnd);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  const padding = 12;
+  const chartWidth = width - padding * 2;
+  const chartHeight = height - padding * 2;
+  if (chartWidth <= 0 || chartHeight <= 0) {
+    return;
+  }
+
+  const history = state.depthHistory;
+  if (!history.length) {
+    ctx.fillStyle = placeholderColor;
+    ctx.font = '600 14px "Segoe UI", Tahoma, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('等待深度資料', width / 2, height / 2);
+    return;
+  }
+
+  let minTime = history[0].time;
+  let maxTime = history[history.length - 1].time;
+  if (minTime === maxTime) {
+    minTime = Math.max(0, minTime - 60);
+  }
+
+  let maxDepthValue = 0;
+  let minDepthValue = Infinity;
+  history.forEach((point) => {
+    maxDepthValue = Math.max(maxDepthValue, point.depth);
+    minDepthValue = Math.min(minDepthValue, point.depth);
+  });
+  if (!Number.isFinite(minDepthValue)) {
+    minDepthValue = 0;
+  }
+
+  const depthPadding = Math.max(1, maxDepthValue * 0.1);
+  const maxDepth = Math.max(5, maxDepthValue + depthPadding);
+  const minDepth = Math.max(0, Math.min(minDepthValue, 0));
+  const depthRange = Math.max(1, maxDepth - minDepth);
+  const timeRange = Math.max(1, maxTime - minTime);
+
+  const getX = (time) => padding + ((time - minTime) / timeRange) * chartWidth;
+  const getY = (depth) => padding + ((depth - minDepth) / depthRange) * chartHeight;
+  const surfaceY = getY(minDepth);
+
+  ctx.save();
+  ctx.strokeStyle = gridColor;
+  ctx.lineWidth = 1;
+  ctx.globalAlpha = 0.4;
+  const gridSteps = 4;
+  for (let i = 0; i <= gridSteps; i += 1) {
+    const y = padding + (chartHeight / gridSteps) * i;
+    ctx.beginPath();
+    ctx.moveTo(padding, y);
+    ctx.lineTo(padding + chartWidth, y);
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  ctx.save();
+  ctx.fillStyle = fillColor;
+  ctx.beginPath();
+  ctx.moveTo(padding, surfaceY);
+  history.forEach((point, index) => {
+    const x = getX(point.time);
+    if (index === 0) {
+      ctx.lineTo(x, surfaceY);
+    }
+    ctx.lineTo(x, getY(point.depth));
+  });
+  ctx.lineTo(getX(history[history.length - 1].time), surfaceY);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+
+  ctx.save();
+  ctx.strokeStyle = lineColor;
+  ctx.lineWidth = 2;
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+  ctx.beginPath();
+  history.forEach((point, index) => {
+    const x = getX(point.time);
+    const y = getY(point.depth);
+    if (index === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  });
+  ctx.stroke();
+  ctx.restore();
+
+  const currentPoint = history[history.length - 1];
+  const currentX = getX(currentPoint.time);
+  const currentY = getY(currentPoint.depth);
+
+  ctx.save();
+  ctx.strokeStyle = markerColor;
+  ctx.lineWidth = 1.5;
+  ctx.setLineDash([6, 4]);
+  ctx.beginPath();
+  ctx.moveTo(padding, currentY);
+  ctx.lineTo(padding + chartWidth, currentY);
+  ctx.stroke();
+  ctx.restore();
+
+  const deepestPoint = history.reduce((maxPoint, point) => (point.depth > maxPoint.depth ? point : maxPoint), history[0]);
+  const deepestX = getX(deepestPoint.time);
+  const deepestY = getY(deepestPoint.depth);
+
+  ctx.save();
+  ctx.fillStyle = markerColor;
+  ctx.beginPath();
+  ctx.arc(currentX, currentY, 4, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.strokeStyle = '#0b1118';
+  ctx.lineWidth = 1;
+  ctx.stroke();
+
+  if (deepestPoint.depth > currentPoint.depth + 0.5) {
+    ctx.beginPath();
+    ctx.arc(deepestX, deepestY, 3, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  }
+  ctx.restore();
 }
 
 function getAmbientPressure(depth) {
@@ -393,6 +573,29 @@ function updateAverages(dtSeconds) {
   }
 }
 
+function recordDepthHistory() {
+  const history = state.depthHistory;
+  if (!history) {
+    return;
+  }
+
+  const time = state.elapsedTime;
+  history.push({ time, depth: state.depth });
+
+  if (Number.isFinite(state.maxHistorySeconds) && state.maxHistorySeconds >= 0) {
+    const cutoff = Math.max(0, time - state.maxHistorySeconds);
+    while (history.length && history[0].time < cutoff) {
+      history.shift();
+    }
+  }
+
+  if (Number.isFinite(state.maxHistoryPoints) && state.maxHistoryPoints >= 0) {
+    if (history.length > state.maxHistoryPoints) {
+      history.splice(0, history.length - state.maxHistoryPoints);
+    }
+  }
+}
+
 function updateDepth(dtSeconds) {
   const previousDepth = state.lastDepth;
   const target = state.targetDepth;
@@ -464,6 +667,7 @@ function tick() {
 
   updateDepth(dtSeconds);
   updateAverages(dtSeconds);
+  recordDepthHistory();
   updateCompartments(dtSeconds);
   updateGas(dtSeconds);
   updateSafetyStop(dtSeconds);
@@ -504,6 +708,7 @@ function reset() {
   state.safetyStopCompleted = false;
   state.lastDepth = 0;
   state.verticalSpeed = 0;
+  state.depthHistory.length = 0;
   resetGasLock();
   clampGradientFactors();
   calculateTankVolumes();
@@ -603,6 +808,10 @@ controls.sac.addEventListener('change', () => {
 });
 
 controls.reset.addEventListener('click', reset);
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('resize', renderDepthChart);
+}
 
 calculateTankVolumes();
 initializeCompartments();

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,13 @@
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background: #10141a;
   color: #f4f7fa;
+  --chart-gradient-start: #1a2b3a;
+  --chart-gradient-end: #0c141d;
+  --chart-grid: rgba(255, 255, 255, 0.06);
+  --chart-line: #26c6da;
+  --chart-fill: rgba(38, 198, 218, 0.22);
+  --chart-marker: #ffcc66;
+  --chart-placeholder: #6f8399;
 }
 
 body {
@@ -65,6 +72,13 @@ body {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 
+.computer__tile--chart {
+  height: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .computer__tile h2 {
   font-size: 0.85rem;
   text-transform: uppercase;
@@ -76,6 +90,37 @@ body {
 .computer__tile p {
   font-size: 1.6rem;
   margin: 0;
+}
+
+.computer__chart-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+p.computer__chart-description,
+.computer__chart-header h2 {
+  margin-bottom: 0;
+}
+
+p.computer__chart-description {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #9fb2c8;
+}
+
+#depth-chart {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  border-radius: 10px;
+  background: linear-gradient(180deg, var(--chart-gradient-start), var(--chart-gradient-end));
+  display: block;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
 .ndl--deco {
@@ -329,6 +374,10 @@ button:disabled {
 
   .computer__tile--wide {
     grid-column: span 1;
+  }
+
+  .computer__tile--chart {
+    height: 200px;
   }
 
   .tank {


### PR DESCRIPTION
## Summary
- default the depth chart history window to unlimited so the entire dive is retained
- only prune depth samples when optional history limits are explicitly set

## Testing
- no automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65c1ae7d8832286fe796faeab6a76