### PR TITLE
Show full dive depth history

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
             <div class="computer__tile computer__tile--wide computer__tile--chart">
               <div class="computer__chart-header">
                 <h2>深度歷史</h2>
-                <p class="computer__chart-description">最近 5 分鐘深度變化</p>
+                <p class="computer__chart-description">整趟潛水深度變化</p>
               </div>
               <canvas id="depth-chart" aria-label="深度歷史圖"></canvas>
             </div>

--- a/script.js
+++ b/script.js
@@ -87,9 +87,7 @@ const state = {
   lockGasSettings: false,
   lastDepth: 0,
   verticalSpeed: 0,
-  depthHistory: [],
-  maxHistorySeconds: 300,
-  maxHistoryPoints: 600
+  depthHistory: []
 };
 
 function initializeCompartments() {
@@ -581,17 +579,6 @@ function recordDepthHistory() {
 
   const time = state.elapsedTime;
   history.push({ time, depth: state.depth });
-
-  const maxSeconds = Number.isFinite(state.maxHistorySeconds) ? state.maxHistorySeconds : 300;
-  const cutoff = Math.max(0, time - maxSeconds);
-  while (history.length && history[0].time < cutoff) {
-    history.shift();
-  }
-
-  const maxPoints = Number.isFinite(state.maxHistoryPoints) ? state.maxHistoryPoints : 600;
-  if (history.length > maxPoints) {
-    history.splice(0, history.length - maxPoints);
-  }
 }
 
 function updateDepth(dtSeconds) {


### PR DESCRIPTION
## Summary
- keep all recorded depth samples for the entire dive instead of trimming to the last five minutes
- update the depth history caption to reflect the full-dive coverage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6601d983c8322823d1d94a0254b63