### PR TITLE
Add higher time scale options for accelerated training

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,8 @@
             <select id="time-scale">
               <option value="1" selected>1×（真實速度）</option>
               <option value="5">5×（加速演練）</option>
+              <option value="10">10×（加速演練）</option>
+              <option value="20">20×（加速演練）</option>
             </select>
             <p class="controls__note">立即生效：改變後下一次更新就會使用新的模擬速度。</p>
           </fieldset>


### PR DESCRIPTION
## Summary
- add 10× and 20× accelerated training options to the time scale selector for simulations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d661488cf08322ab22fe6f966a4a65