### PR TITLE
Revamp safety stop display

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,12 @@
             </div>
             <div class="computer__tile">
               <h2>無減壓極限 / 安全停留</h2>
-              <p><span id="ndl">--</span><span id="ndl-unit"> 分鐘</span></p>
+              <div class="ndl-display" id="ndl-display">
+                <span class="ndl-display__label" id="ndl-label">無減壓極限</span>
+                <div class="ndl-display__value">
+                  <span id="ndl">--</span><span id="ndl-unit"> 分鐘</span>
+                </div>
+              </div>
             </div>
           </div>
           <div class="computer__row">

--- a/script.js
+++ b/script.js
@@ -35,6 +35,8 @@ const ui = {
   currentDepth: document.getElementById('current-depth'),
   diveTime: document.getElementById('dive-time'),
   ndl: document.getElementById('ndl'),
+  ndlContainer: document.getElementById('ndl-display'),
+  ndlLabel: document.getElementById('ndl-label'),
   ndlUnit: document.getElementById('ndl-unit'),
   tts: document.getElementById('tts'),
   avgDepth: document.getElementById('avg-depth'),
@@ -134,28 +136,49 @@ function updateUI() {
 
   const ndl = calculateNDL();
   const decoPlan = ndl <= 0 ? calculateDecoStop() : null;
-  ui.ndl.classList.remove('ndl--safety');
-  ui.ndl.classList.remove('ndl--deco');
   const ndlUnit = ui.ndlUnit;
+  const ndlLabel = ui.ndlLabel;
+  const ndlContainer = ui.ndlContainer;
+
+  if (ndlContainer) {
+    ndlContainer.classList.remove('ndl--safety-pause', 'ndl--safety-active', 'ndl--deco');
+  }
+  if (ndlLabel) {
+    ndlLabel.textContent = '無減壓極限';
+  }
+  if (ndlUnit) {
+    ndlUnit.textContent = ' 分鐘';
+  }
 
   if (state.safetyStopRequired && !state.safetyStopCompleted) {
     const remainingSeconds = Math.max(0, Math.ceil(state.safetyStopTimer));
-    ui.ndl.textContent = `${remainingSeconds}`;
-    if (ndlUnit) {
-      ndlUnit.textContent = ' 秒';
-    }
-    ui.ndl.classList.add('ndl--safety');
-  } else if (decoPlan) {
-    const stopMinutes = decoPlan.duration / 60;
-    ui.ndl.textContent = `DECO STOP ${decoPlan.depth.toFixed(0)}m / ${stopMinutes.toFixed(1)}`;
+    ui.ndl.textContent = formatTime(remainingSeconds);
     if (ndlUnit) {
       ndlUnit.textContent = '';
     }
-    ui.ndl.classList.add('ndl--deco');
-  } else {
-    ui.ndl.textContent = Number.isFinite(ndl) ? ndl.toFixed(0) : '∞';
+    if (ndlLabel) {
+      ndlLabel.textContent = state.safetyStopActive ? 'Safety Stop' : 'Safety Pause';
+    }
+    if (ndlContainer) {
+      ndlContainer.classList.add(state.safetyStopActive ? 'ndl--safety-active' : 'ndl--safety-pause');
+    }
+  } else if (decoPlan) {
+    if (ndlLabel) {
+      ndlLabel.textContent = '減壓停留';
+    }
+    const stopMinutes = decoPlan.duration / 60;
+    ui.ndl.textContent = `${decoPlan.depth.toFixed(0)} 公尺`;
     if (ndlUnit) {
-      ndlUnit.textContent = ' 分鐘';
+      ndlUnit.textContent = ` · ${stopMinutes.toFixed(1)} 分鐘`;
+    }
+    if (ndlContainer) {
+      ndlContainer.classList.add('ndl--deco');
+    }
+  } else {
+    const ndlValue = Number.isFinite(ndl) ? ndl.toFixed(0) : '∞';
+    ui.ndl.textContent = ndlValue;
+    if (ndlUnit) {
+      ndlUnit.textContent = Number.isFinite(ndl) ? ' 分鐘' : '';
     }
   }
   ui.tts.textContent = calculateTTS().toFixed(1);

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,15 @@
   --chart-fill: rgba(38, 198, 218, 0.22);
   --chart-marker: #ffcc66;
   --chart-placeholder: #6f8399;
+  --ndl-base-bg: rgba(19, 28, 38, 0.65);
+  --ndl-label-color: #9fb2c8;
+  --ndl-value-color: #f4f7fa;
+  --ndl-safety-pause-bg: rgba(255, 196, 69, 0.16);
+  --ndl-safety-pause-border: rgba(255, 196, 69, 0.45);
+  --ndl-safety-pause-text: #ffd47a;
+  --ndl-safety-active-bg: rgba(255, 107, 107, 0.16);
+  --ndl-safety-active-border: rgba(255, 107, 107, 0.45);
+  --ndl-safety-active-text: #ff9898;
 }
 
 body {
@@ -92,6 +101,41 @@ body {
   margin: 0;
 }
 
+.ndl-display {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.75rem 1rem;
+  background: var(--ndl-base-bg);
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.ndl-display__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ndl-label-color);
+}
+
+.ndl-display__value {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-size: 2.5rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--ndl-value-color);
+}
+
+#ndl-unit {
+  font-size: 1rem;
+  letter-spacing: 0.06em;
+  color: var(--ndl-label-color);
+}
+
 .computer__chart-header {
   display: flex;
   align-items: baseline;
@@ -124,13 +168,39 @@ p.computer__chart-description {
 }
 
 .ndl--deco {
+  background: rgba(255, 107, 107, 0.12);
+  border-color: rgba(255, 107, 107, 0.4);
   color: #ff6b6b;
-  font-weight: 700;
 }
 
-.ndl--safety {
-  color: #ffcc66;
-  font-weight: 700;
+.ndl--deco .ndl-display__label,
+.ndl--deco .ndl-display__value,
+.ndl--deco #ndl-unit {
+  color: inherit;
+}
+
+.ndl--safety-pause {
+  background: var(--ndl-safety-pause-bg);
+  border-color: var(--ndl-safety-pause-border);
+  color: var(--ndl-safety-pause-text);
+}
+
+.ndl--safety-pause .ndl-display__label,
+.ndl--safety-pause .ndl-display__value,
+.ndl--safety-pause #ndl-unit {
+  color: inherit;
+}
+
+.ndl--safety-active {
+  background: var(--ndl-safety-active-bg);
+  border-color: var(--ndl-safety-active-border);
+  color: var(--ndl-safety-active-text);
+}
+
+.ndl--safety-active .ndl-display__label,
+.ndl--safety-active .ndl-display__value,
+.ndl--safety-active #ndl-unit {
+  color: inherit;
 }
 
 .computer__tile--wide {


### PR DESCRIPTION
## Summary
- restructure the NDL area markup to support dedicated labels and multi-line layouts
- update the UI logic to format safety stop timers, set the correct labels, and toggle new styling classes
- add safety pause/active styling tokens so the NDL panel reflects the latest safety designs

## Testing
- Manual verification in local browser

------
https://chatgpt.com/codex/tasks/task_e_68d66521f494832280e36803acd78263